### PR TITLE
Allow usage in Ruby 3 projects

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,20 +12,20 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7, 3.0]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - name: Update the RubyGems system software
-      run: gem update --system
-    - name: Update Bundler
-      run: bundle update --bundler
-    - name: Install dependencies
-      run: bundle install
-    - name: Run tests
-      run: bundle exec rspec
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Update the RubyGems system software
+        run: gem update --system
+      - name: Update Bundler
+        run: bundle update --bundler
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: ruby
 rvm:
   - 2.5.0
   - 2.6.0
+  - 3.0.0
 before_install:
   - gem update --system
   - bundle update --bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cleanup_vendor (0.5.0)
+    cleanup_vendor (0.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/cleanup_vendor.gemspec
+++ b/cleanup_vendor.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.5'
+  spec.required_ruby_version = '> 2.5'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'gem-release', '~> 2.1'

--- a/lib/cleanup_vendor.rb
+++ b/lib/cleanup_vendor.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'fileutils'
 require 'yaml'
 
 require 'cleanup_vendor/version'

--- a/lib/cleanup_vendor/version.rb
+++ b/lib/cleanup_vendor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CleanupVendor
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
I'm using this in a project that is being upgraded to Ruby 3 and the `required_ruby_version` is restricting this to only Ruby versions greater than 2.5 but less than 3.0.

Additionally, when testing this update, it seems that `FileUtils` was not being required and needs to be, so I added a require. It's not clear why this became a problem, and if there is another solution you'd prefer to this, let me know.