### PR TITLE
fix: require set for ruby 3.0.1

### DIFF
--- a/lib/cleanup_vendor.rb
+++ b/lib/cleanup_vendor.rb
@@ -2,6 +2,7 @@
 
 require 'fileutils'
 require 'yaml'
+require 'set'
 
 require 'cleanup_vendor/version'
 require 'cleanup_vendor/path'


### PR DESCRIPTION
Looks like Ruby 3.0.1 needs an explicit require set.

The error that appears looks something like this:

```
/opt/bitnami/ruby/lib/ruby/gems/3.0.0/gems/cleanup_vendor-0.6.0/lib/cleanup_vendor.rb:51:in `block in get_options': undefined method `to_set' for ["**/.DS_Store", "**/*.{c,cpp,h,hpp,java,log,markdown,md,mk,o,orig,rdoc,txt}", "**/gem_make.out", "**/Makefile", "**/TAGS", "**/*.{gcov,gem}", "**/*.{log,markdown,md,rdoc,txt,yardopts}", "**/*.{bak,orig}", "**/{CHANGELOG,CHANGES,LICENSE,MIT-LICENSE,NEWS,README,TODO}", "**/.{gitkeep,gitignore,gitmodules}", "**/.keep", "**/{Dockerfile,.dockerignore}", "**/Guardfile", "**/.{appveyor,codeclimate,hound,travis}.yml", "**/.{ruby-gemset,ruby-version,rvm}", "**/.{rspec,rspec_status}", "**/.npmignore", "**/.rubocop.yml", "**/.byebug_history"]:Array (NoMethodError)
Did you mean?  to_s
    from /opt/bitnami/ruby/lib/ruby/gems/3.0.0/gems/cleanup_vendor-0.6.0/lib/cleanup_vendor.rb:50:in `map'
    from /opt/bitnami/ruby/lib/ruby/gems/3.0.0/gems/cleanup_vendor-0.6.0/lib/cleanup_vendor.rb:50:in `get_options'
    from /opt/bitnami/ruby/lib/ruby/gems/3.0.0/gems/cleanup_vendor-0.6.0/lib/cleanup_vendor.rb:36:in `filter'
    from /opt/bitnami/ruby/lib/ruby/gems/3.0.0/gems/cleanup_vendor-0.6.0/lib/cleanup_vendor.rb:19:in `run'
    from /opt/bitnami/ruby/lib/ruby/gems/3.0.0/gems/cleanup_vendor-0.6.0/exe/cleanup_vendor:61:in `<top (required)>'
    from /opt/bitnami/ruby/bin/cleanup_vendor:23:in `load'
    from /opt/bitnami/ruby/bin/cleanup_vendor:23:in `<main>'
```